### PR TITLE
Modify regex for parsing Distributor ID. 

### DIFF
--- a/Code/CMake/SimVascularSystemSetup.cmake
+++ b/Code/CMake/SimVascularSystemSetup.cmake
@@ -172,7 +172,7 @@ elseif(LINUX)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   # Get distribution name and version number from lsb_release output
-  STRING(REGEX REPLACE "Distributor ID:[\t]*([^ \n\r]+).*$" "\\1" LSB_DISTRIB "${LSB_RELEASE_INFO}")
+  STRING(REGEX REPLACE "^.*Distributor ID:[\t]*([^ \n\r]+).*$" "\\1" LSB_DISTRIB "${LSB_RELEASE_INFO}")
   STRING(REGEX REPLACE "^.*Release:[\t]*([^ \n\r]+).*$" "\\1" LSB_VERSION "${LSB_RELEASE_INFO}")
   string(TOLOWER "${LSB_DISTRIB}" _platform_lower)
 


### PR DESCRIPTION
There was a problem parsing the output of the lsb_release command to get the distribution ID (i.e. ubuntu), see GitHub SimVascular Issue #376.

This was a problem for Ubuntu 16, assume that this also works for later versions.